### PR TITLE
Update Amazon IVS Player SDK to 1.16.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'Live to VOD UIKit' do
-  pod 'AmazonIVSPlayer', '~> 1.14.0'
+  pod 'AmazonIVSPlayer', '~> 1.16.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.14.0)
+  - AmazonIVSPlayer (1.16.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.14.0)
+  - AmazonIVSPlayer (~> 1.16.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: afa368571fe046e99900c88ef891755e01f44bc5
+  AmazonIVSPlayer: e9092086094e70ba1e39b3f6f57f623da05b4b27
 
-PODFILE CHECKSUM: 53994d84f33022fac2f8910d89fd7a8b8322e594
+PODFILE CHECKSUM: fbb9658ebf2bcdef6129bc07331cb4136629add6
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.16.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
