### PR TITLE
Seek to start of the vod when slider is moved to start position

### DIFF
--- a/Live to VOD UIKit/Controllers/ViewController.swift
+++ b/Live to VOD UIKit/Controllers/ViewController.swift
@@ -500,7 +500,10 @@ class ViewController: UIViewController {
             seekStatus = nil
             return
         }
-        let position = CMTimeMultiplyByFloat64(vodPlayer.duration, multiplier: Float64(fraction))
+        let position = CMTimeMultiplyByFloat64(
+            vodPlayer.duration,
+            multiplier: Float64(fraction == 0 ? 0.000001 : fraction)
+        )
         seek(to: position)
     }
 


### PR DESCRIPTION
Fixes the issue where video position was not updated when seek slider value was set to 0.
Now when this happens, the player will seek to 0.000001 fraction of recorded video duration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
